### PR TITLE
Add option to show today's collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Copy all files from custom_components/awb/ to custom_components/awb/ inside your
 https://community.home-assistant.io/t/awb-waste-collection-schedule/140486
 
 ## Functionality
-The sensor shows the bin which will be collected the next day. The complete collection schedule is available as attributes of the sensor 
+The sensor shows the bin which will be collected the next day. The complete collection schedule is available as attributes of the sensor.
+Optionally, the collection of the current day can be selected by setting `day: today`
 
 ![alt text](https://github.com/jensweimann/awb/blob/master/preview1.png "glance card")
 
@@ -38,6 +39,7 @@ street_number: 4
   scan_interval: 3600
   street_code: 745
   street_number: 4
+  date: tomorrow
 ```
 
 ### customize

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ street_number: 4
   scan_interval: 3600
   street_code: 745
   street_number: 4
-  date: tomorrow
+  day: tomorrow
 ```
 
 ### customize


### PR DESCRIPTION
Living in the city center, the kind garbage collectors are getting the bins from the basement for us and we don't need to put them outside ourselves. The problem for us is though to know the days where chances are highest to find space in the bins for our trash. So on a "yellow" day, I will go downstairs after the bins have been emptied to get rid of my recyclables.

A new config attribute `day: today` changes the behavior to show me today's collections. In a subsequent improvement, I can imagine an attribute like `days_since_collection` to estimate how full the bins currently are.